### PR TITLE
Changes from 8.2

### DIFF
--- a/xapi/storage/libs/libcow/metabase.py
+++ b/xapi/storage/libs/libcow/metabase.py
@@ -1,6 +1,8 @@
 """
 Metadata database for virtual disks
 """
+from xapi.storage import log
+from xapi.storage.libs import util
 import sqlite3
 
 
@@ -330,8 +332,17 @@ class VolumeMetabase(object):
 
     def dump(self, path):
         with open(path, 'w') as file:
-            for line in self._conn.iterdump():
-                file.write("{}\n".format(line))
+            try:
+                import codecs
+                encoder = codecs.getincrementalencoder('utf-8')()
+                for line in self._conn.iterdump():
+                    file.write("{}\n".format(encoder.encode(line)))
+            except Exception as e:
+                log.error(
+                    'Failed to dump the metabase to {}: {}'.format(path, e)
+                )
+                util.remove_path(path, Force=True)
+                raise e
 
     def insert_vdi(self, name, description, uuid, volume_id, sharable):
         """


### PR DESCRIPTION
This PR cherry-picks the following commits:
1) "feat(coalesce): GC can be disabled now if '/var/lib/sr/{sr_id}/gc_disabled' exists"
2) "feat(metabase): dump database using utf8 + remove dumped file in case of error"

The commit at (1 required a bit of rework. To test (1, I enabled/disabled the gc by creating the file at '/var/lib/sr/{sr_id}/gc_disabled'. I have attached the logs to see the different behaviors.
To test (2, I tested with the patch and I did not observe any weird char in the dump database. I have attached the logs.

[logswithpatch.sql.txt](https://github.com/xcp-ng/xcp-ng-xapi-storage/files/8087842/logswithpatch.sql.txt)
[SMlogwitgc_disabled.txt](https://github.com/xcp-ng/xcp-ng-xapi-storage/files/8087825/SMlogwitgc_disabled.txt)
[SMlogwithoutgc_disabled.txt](https://github.com/xcp-ng/xcp-ng-xapi-storage/files/8087826/SMlogwithoutgc_disabled.txt)
