### PR TITLE
util.call*: fix error reporting

### DIFF
--- a/xapi/storage/libs/util.py
+++ b/xapi/storage/libs/util.py
@@ -24,7 +24,7 @@ class CommandException(Exception):
         self.code = code
         self.cmd = cmd
         self.reason = reason
-        Exception.__init__(self, os.strerror(abs(code)))
+        Exception.__init__(self, reason)
 
 
 def mkdir_p(path, mode=0o777):


### PR DESCRIPTION
Trying to interpret the exit status of arbitrary called processes as an errno value, and disregard the stderr content we extract for a reason, had little chance to be useful.