### PR TITLE
qemuback: ship systemd xapi.service integration

### DIFF
--- a/daemons/qemuback/xapi-qemuback.conf
+++ b/daemons/qemuback/xapi-qemuback.conf
@@ -1,0 +1,4 @@
+# to be installed in /etc/systemd/system/xapi.service.d/
+[Unit]
+Wants=qemuback.service
+After=qemuback.service


### PR DESCRIPTION
This is getting removed from xcp-ng-release for more fine-grained installation (since this service does not ship yet in 8.3).